### PR TITLE
Unstable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ include_directories(reddit-save-archiver)
 option(DEBUG "Enable debugging" OFF)
 option(RELEASE "release build" ON)
 
+if(USE_HOME_DIR)
+	add_compile_options(-DUSE_HOME_DIR)
+endif()
+
 if(DEBUG)
 	add_compile_options(-D_DEBUG=1)
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/debug)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ if(USE_HOME_DIR)
 	add_compile_options(-DUSE_HOME_DIR)
 endif()
 
-if(EXP_FS)
-	add_compile_options(-DEXP_FS)
+if(USE_EXP_FS)
+	add_compile_options(-DUSE_EXP_FS)
 endif()
 
 if(DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ if(USE_HOME_DIR)
 	add_compile_options(-DUSE_HOME_DIR)
 endif()
 
+if(EXP_FS)
+	add_compile_options(-DEXP_FS)
+endif()
+
 if(DEBUG)
 	add_compile_options(-D_DEBUG=1)
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/debug)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Run RSA without any flags if you want everything thats scanned
 		-r/-reverse: reverse the list of items collected from save
     -uw [user,user]: Enable whitelisting users
     -ub	[user,user]: Enable blacklisting of users
+    -bd [domain,domain] : Enable blacklisting of domain names
+    -bw [domain,domain] : Enable whitelisting of domain names
 ```
 
 ## Known Issues / Notes

--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@ Reddit-Save-Archiver is a Reddit tool where it saves posts, comments, pictures t
 
 ## Building RSA/RST
 
-Building RSA is relatively simple by just configuring cmake to your preffered compiler/platform and compiling it through the generated Makefile:
+For most people compiling RSA can be accomplished by running cmake then make.
 
 ```
 cmake -G "COMPILER_HERE"
+make
 ```
+
+However for some compilers, the -DUSE_EXP_FS=1 flag is needed. This is because the way RSA detects <filesystem> may not work for some compilers.
+
+```
+cmake -G "COMPILER_HERE" -DUSE_EXP_FS=1
+```
+
+Another cmake option you can add, is the USE_HOME_DIR. This flag stores media and logs in ~/RSA/ on Linux.
 
 ### RSA depends on:
 1. Boost's headers
@@ -29,7 +38,11 @@ Before you start RSA, you need to setup your credentials from https://www.reddit
             "user_agent": "useragent_here",
             "username": "username_here"
         }
-    ]
+    ],
+    "imgur" : {
+      "client_id": "cid"
+    }
+
 }
 
 ```
@@ -66,5 +79,4 @@ Run RSA without any flags if you want everything thats scanned
 
 1. Fix the aformentioned issues
 2. Add more options for directory structure E.g /Sub/Post_tite/[Content]
-2. Add things like author, permalink and etc to the text files
 3. Create GUI for RSA

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Run RSA without any flags if you want everything thats scanned
 		-v/-version: Version
 		-sb/sortby [sort]: Sorts downloaded media by: title,subreddit,id or unsorted; with the default being subreddit
 		-r/-reverse: reverse the list of items collected from save
+    -uw [user,user]: Enable whitelisting users
+    -ub	[user,user]: Enable blacklisting of users
 ```
-   
+
 ## Known Issues / Notes
 
 1. Not really an issues/bug, but RSA doesn't support downloading video, but I want to try to support it in the future

--- a/Reddit.cpp
+++ b/Reddit.cpp
@@ -108,6 +108,15 @@ bool RedditAccess::load_login_info()
 			std::clog << "Account: " << this->Account->username << " loaded." << std::endl;
 		}
 		is_logged_in = true;
+
+
+		try {
+			auto imgur = root.at("imgur");
+
+			//this->Account.
+		} catch(nlohmann::json::exception& e) {
+			
+		}
 		success = true;
 	}
 	catch (nlohmann::json::exception& e) {

--- a/Reddit.cpp
+++ b/Reddit.cpp
@@ -17,12 +17,17 @@ void RedditAccess::init_logs() {
 	std::strftime(datestr, sizeof(datestr), "%Y-%m-%d ", timeinfo);
 #endif
 
-#if !defined(USE_HOME_DIR)
+
+#if defined(USE_HOME_DIR)
+	char* homedir = getenv("HOME");
+	if(homedir == NULL)
+		homedir = getpwuid(getuid())->pw_dir;
+
+	this->mediapath = std::string(homedir) + "/RSA/media/" + std::string(datestr) + "/" + Account->username + "/";
+	this->logpath = std::string(homedir) + "/RSA/logs/" + std::string(datestr) + "/" + Account->username + "/";
+#else
 	this->logpath = std::string(fs::current_path().u8string()) + "/logs/" + std::string(datestr) + "/" + Account->username + "/";
 	this->mediapath = std::string(fs::current_path().u8string()) + "/media/" + std::string(datestr) + "/" + Account->username + "/";
-#else
-	this->mediapath = "~/RSA/logs/" + std::string(datestr) + "/" + Account->username + "/";
-	this->logpath = "~/RSA/media/" + std::string(datestr) + "/" + Account->username + "/";
 #endif
 	std::clog << "Current log to be generated at: " << this->logpath << std::endl;
 
@@ -36,7 +41,7 @@ void RedditAccess::init_logs() {
 	std::clog << "Beginning log." << std::endl;
 }
 
-RedditAccess::RedditAccess() : log(nullptr), is_logged_in(false)
+RedditAccess::RedditAccess() : log(nullptr), is_logged_in(false), requests_done(0), request_done_in_current_minute(0)
 {
 }
 

--- a/Reddit.cpp
+++ b/Reddit.cpp
@@ -280,16 +280,15 @@ void RedditAccess::is_mtime_up()
 #endif
 		std::clog << "60 requests limit per minute has hit, stalling." << std::endl;
 		// Stall then reset time
-		while (mnow != mthen) {
-			// stall
-
-			if (mnow >= mthen){
-				std::clog << "Minute clock is reset" << std::endl;
-				restart_minute_clock(); break;
-			}
-		}
-	}
-	else if (mnow >= mthen) {
+		#ifdef _WIN32
+		Sleep(60000);
+		#elif _unix
+		usleep(60);
+		#else
+		usleep(60);
+		#endif
+		restart_minute_clock();
+		} else if (mnow >= mthen) {
 		std::clog << "Restarting the minute clock!" << std::endl;
 		restart_minute_clock();
 	}
@@ -363,6 +362,112 @@ State RedditAccess::retrieve_imgur_image(std::string imghash, std::string& URL)
 	} else {
 		s.message = "Failed to load libcurl handle!";
 		s.http_state = -1;
+	}
+	return s;
+}
+
+State RedditAccess::retrieve_album_images(std::string albumhash, std::vector<std::string>& URLs)
+{
+	State s;
+	CURL* handle;
+	CURLcode result;
+	std::string rdata, hd;
+
+	handle = curl_easy_init();
+
+	if(handle)
+	{
+		curl_global_init(CURL_GLOBAL_ALL);
+		struct curl_slist* header = nullptr;
+		 std::string sheader = "Authorization: Client-ID " + this->imgur_client_id;
+		 header = curl_slist_append(header, sheader.c_str());
+
+		 std::string URL = "https://api.imgur.com/3/album/" + albumhash;
+		 curl_easy_setopt(handle, CURLOPT_URL, URL.c_str());
+		 curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
+	 	 curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+	 	 curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+	 	 curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &writedat);
+	 	 curl_easy_setopt(handle, CURLOPT_WRITEDATA, &rdata);
+	 	 curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+	 	 curl_easy_setopt(handle, CURLOPT_HEADERDATA, &hd);
+
+		 result = curl_easy_perform(handle);
+		 curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &s.http_state);
+		 curl_easy_cleanup(handle);
+		 curl_global_cleanup();
+		 curl_slist_free_all(header);
+
+		 #ifdef _DEBUG
+		 JQFIO(std::string("imgur_album_") + albumhash + ".txt", rdata);
+		 #endif
+
+		 if(result != CURLE_OK)
+		 {
+			 s.message = curl_easy_strerror(result);
+		 } else {
+			 nlohmann::json root;
+			 try {
+			 	root = nlohmann::json::parse(rdata);
+				nlohmann::json images = root.at("data").at("images");
+				for(auto& elem : images)
+				{
+					URLs.push_back(elem.at("link").get<std::string>());
+				}
+		 	} catch(nlohmann::json::exception& e) {
+				s.message = e.what();
+				s.http_state = -1;
+				return s;
+			}
+			s.message = "";
+		 }
+	} else {
+		s.http_state = -1;
+		s.message = "Failed to initialize libcurl handle!";
+	}
+	return s;
+}
+
+State RedditAccess::download_item(const char* URL, std::string dest, std::string fn)
+{
+
+	//std::cout << "Retrieving Imgur album" << std::endl;
+	CURL* handle;
+	CURLcode result;
+	State s;
+	std::string rdata, hd;
+
+	handle = curl_easy_init();
+	if(handle)
+	{
+		curl_global_init(CURL_GLOBAL_ALL);
+		curl_easy_setopt(handle, CURLOPT_URL, URL);
+		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+		curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &writedat);
+		curl_easy_setopt(handle, CURLOPT_WRITEDATA, &rdata);
+		curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+		curl_easy_setopt(handle, CURLOPT_HEADERDATA, &hd);
+
+		result = curl_easy_perform(handle);
+		curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &s.http_state);
+		curl_easy_cleanup(handle);
+
+		if(result != CURLE_OK)
+		{
+			s.message = curl_easy_strerror(result);
+		} else {
+			//check if the destination exists
+			if(!fs::exists(dest))
+				fs::create_directories(dest);
+			// store image
+			std::fstream out(dest + "/" + fn, std::ios::out);
+			out << rdata;
+		}
+
+		s.message = "";
+	} else {
+		s.http_state = -1;
+		s.message = "Failed to initialize libcurl handle!";
 	}
 	return s;
 }

--- a/Reddit.cpp
+++ b/Reddit.cpp
@@ -327,7 +327,9 @@ State RedditAccess::retrieve_imgur_image(std::string imghash, std::string& URL)
 		curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
 		curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &writedat);
 		curl_easy_setopt(handle, CURLOPT_WRITEDATA, &rdata);
+		#ifdef _DEBUG
 		curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+		#endif
 		curl_easy_setopt(handle, CURLOPT_HEADERDATA, &hd);
 		result = curl_easy_perform(handle);
 
@@ -389,7 +391,9 @@ State RedditAccess::retrieve_album_images(std::string albumhash, std::vector<std
 	 	 curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
 	 	 curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &writedat);
 	 	 curl_easy_setopt(handle, CURLOPT_WRITEDATA, &rdata);
+		 #ifdef _DEBUG
 	 	 curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+		 #endif
 	 	 curl_easy_setopt(handle, CURLOPT_HEADERDATA, &hd);
 
 		 result = curl_easy_perform(handle);
@@ -447,6 +451,9 @@ State RedditAccess::download_item(const char* URL, std::string dest, std::string
 		curl_easy_setopt(handle, CURLOPT_WRITEDATA, &rdata);
 		curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
 		curl_easy_setopt(handle, CURLOPT_HEADERDATA, &hd);
+		#ifdef _DEBUG
+		curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+		#endif
 
 		result = curl_easy_perform(handle);
 		curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &s.http_state);

--- a/Reddit.cpp
+++ b/Reddit.cpp
@@ -315,7 +315,7 @@ State RedditAccess::authorize_imgur()
 
 		curl_easy_setopt(handle, CURLOPT_URL, "https://api.imgur.com/oauth2/authorize");
 		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
-		std::string params = "?client_id=" + Account->imgur_client_id + "&response_type=token";
+		std::string params = "client_id=" + Account->imgur_client_id + "&response_type=token";
 		curl_easy_setopt(handle, CURLOPT_POSTFIELDS, params.c_str());
 		curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &writedat);
 		curl_easy_setopt(handle, CURLOPT_WRITEDATA, &data);

--- a/Reddit.hpp
+++ b/Reddit.hpp
@@ -26,6 +26,8 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <pwd.h>
+#else
+#include <Synchapi.h>
 #endif
 
 class RedditAccess {
@@ -92,8 +94,9 @@ public:
 	// Imgur credentials
 	std::string imgur_client_id;
 	bool imgur_enabled;
-	State retrieve_album_images(std::string album_id);
+	State retrieve_album_images(std::string album_id, std::vector<std::string>& URLs);
 	State retrieve_imgur_image(std::string imghash, std::string& URL);
+	State download_item(const char* URL, std::string dest, std::string fn);
 
 
 };

--- a/Reddit.hpp
+++ b/Reddit.hpp
@@ -78,6 +78,7 @@ public:
 	// Imgur credentials
 	std::string imgur_acctoken, imgur_reftoken, imgur_ac;
 	int imgur_pin;
+	bool imgur_enabled;
 	State authorize_imgur();
 	State retrieve_album_images(std::string album_id);
 

--- a/Reddit.hpp
+++ b/Reddit.hpp
@@ -2,18 +2,27 @@
 #include <string>
 #include "base.hpp"
 #include <chrono>
-#if defined(EXP_FS)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
 #include <ctime>
-#include "nlohmann/json.hpp"
 #include <fstream>
+
+#include "nlohmann/json.hpp"
 #include "curl/curl.h"
-#if defined(unix)
+
+#if defined(__cpp_lib_filesystem)
+	#include <filesystem>
+	namespace fs = std::filesystem;
+#elif defined(__cpp_lib_experimental_filesystem)
+	#include <experimental/filesystem>
+	namespace fs = std::experimental::filesystem;
+#elif defined(USE_EXP_FS)
+	#include <experimental/filesystem>
+	namespace fs = std::experimental::filesystem;
+#else
+	#error "No filesystem support found :("
+#endif
+
+
+#if defined(unix) || defined(_unix)
 #include <unistd.h>
 #include <sys/types.h>
 #include <pwd.h>
@@ -81,11 +90,10 @@ public:
 		Below here is an implementation for better support for imgur images
 	*/
 	// Imgur credentials
-	std::string imgur_acctoken, imgur_reftoken, imgur_ac;
-	int imgur_pin;
+	std::string imgur_client_id;
 	bool imgur_enabled;
-	State authorize_imgur();
 	State retrieve_album_images(std::string album_id);
+	State retrieve_imgur_image(std::string imghash, std::string& URL);
 
 
 };

--- a/Reddit.hpp
+++ b/Reddit.hpp
@@ -2,7 +2,7 @@
 #include <string>
 #include "base.hpp"
 #include <chrono>
-#if defined(__GNUC__) && !(defined(__MINGW64__) || defined(__MINGW32__))
+#if defined(EXP_FS)
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #else

--- a/Reddit.hpp
+++ b/Reddit.hpp
@@ -13,6 +13,11 @@ namespace fs = std::filesystem;
 #include "nlohmann/json.hpp"
 #include <fstream>
 #include "curl/curl.h"
+#if defined(unix)
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#endif
 
 class RedditAccess {
 public:

--- a/Reddit.hpp
+++ b/Reddit.hpp
@@ -76,10 +76,10 @@ public:
 		Below here is an implementation for better support for imgur images
 	*/
 	// Imgur credentials
-	/*std::string imgur_acctoken, imgur_reftoken, imgur_ac;
+	std::string imgur_acctoken, imgur_reftoken, imgur_ac;
 	int imgur_pin;
 	State authorize_imgur();
-	State retrieve_album_images(std::string album_id);*/
+	State retrieve_album_images(std::string album_id);
 
 
 };

--- a/Reddit.hpp
+++ b/Reddit.hpp
@@ -72,5 +72,14 @@ public:
 	void tick();
 
 
+	/*
+		Below here is an implementation for better support for imgur images
+	*/
+	// Imgur credentials
+	/*std::string imgur_acctoken, imgur_reftoken, imgur_ac;
+	int imgur_pin;
+	State authorize_imgur();
+	State retrieve_album_images(std::string album_id);*/
+
 
 };

--- a/Saver.cpp
+++ b/Saver.cpp
@@ -445,8 +445,6 @@ void Saver::download_content(std::vector<Item*> i)
 
 	for (size_t j = 0; j < (unsigned)args.limit; j++) {
 		Item *elem = i[j];
-		bool imgur_album = false;
-		bool imgur = false;
 
 		#ifdef _DEBUG
 		std::cout << elem->url << std::endl;
@@ -512,7 +510,8 @@ void Saver::download_content(std::vector<Item*> i)
 		}
 		path += "/";
 
-		if (elem->IsImgurAlbum()){
+		if (elem->IsImgurAlbum())
+		{
 			std::vector<std::string> vih, vai;
 			boost::split(vih, elem->url, boost::is_any_of("/"));
 
@@ -526,7 +525,7 @@ void Saver::download_content(std::vector<Item*> i)
 			}
 			std::string dest = path + elem->title;
 			std::string fn;
-			std::cout << "Retrieving imgur album: " << hash << " from " << elem->subreddit << std::endl;
+			std::cout << "Retrieving imgur album: " << elem->url << " from " << elem->subreddit << std::endl;
 			for(int i = 0; i < vai.size(); i++)
 			{
 				std::vector<std::string> _vih;
@@ -539,8 +538,9 @@ void Saver::download_content(std::vector<Item*> i)
 					std::cout << "Error failed to retrieve " << i << " of " << vai.size() << std::endl;
 					std::cout << "Reason: " << res.message << std::endl;
 				}
-				std::cout << "Retrieving: " << i << " of " << vai.size() << "\r" << std::endl;
+				std::cout << "Retrieving: " << i << " of " << vai.size() << std::endl;
 			}
+			std::cout << std::endl;
 		} else if( elem->IsImgurLink() && imgur_enabled) {
 			std::string url = elem->url;
 			std::clog << "Retrieving Imgur image: " << url << std::endl;
@@ -610,7 +610,7 @@ void Saver::download_content(std::vector<Item*> i)
 				std::vector<std::string> res;
 				boost::split(res, ct, boost::is_any_of("/"));
 				if (args.EnableImages) {
-					if ((res[0] == "image" || imgur) && !fs::exists(path)) {
+					if ((res[0] == "image") && !fs::exists(path)) {
 						try {
 							fs::create_directories(path);
 						}
@@ -623,10 +623,7 @@ void Saver::download_content(std::vector<Item*> i)
 					if (res[0] == "image") {
 						std::ofstream(path + elem->id + "." + res[1], std::ios::binary) << data;
 						std::clog << "Content: " << elem->id << " stored at " << path << std::endl;
-					}
-					if (imgur_album) {
-						std::ofstream(path + elem->id + ".zip", std::ios::binary) << data;
-						std::clog << "Content: " << elem->id << " stored at " << path << std::endl;
+						std::cout << "Retrieving content: " << elem->url << " from " << elem->permalink << std::endl;
 					}
 				}
 				if (args.EnableText) {
@@ -655,6 +652,7 @@ void Saver::download_content(std::vector<Item*> i)
 						else{
 							out << elem->orig_self_text << std::endl;
 						}
+						std::cout << "Retrieving content: " << elem->permalink << std::endl;
 
 					}
 

--- a/Saver.cpp
+++ b/Saver.cpp
@@ -502,8 +502,12 @@ void Saver::download_content(std::vector<Item*> i)
 			path += elem->id;
 			break;
 		case Title:
+		{
+			if(elem->title.size() > 255)
+				elem->title.resize(255);
 			path += stripfname(elem->title);
 			break;
+		}
 		default:
 			// Unsorted
 			break;
@@ -523,6 +527,10 @@ void Saver::download_content(std::vector<Item*> i)
 				std::cout << "Error: Failed to retrieve Imgur album URLs, " << iam.message << std::endl;
 				continue;
 			}
+
+			if(elem->title.size() > 255)
+				elem->title.resize(255);
+
 			std::string dest = path + elem->title;
 			std::string fn;
 			std::cout << "Retrieving imgur album: " << elem->url << " from " << elem->subreddit << std::endl;

--- a/Saver.hpp
+++ b/Saver.hpp
@@ -34,12 +34,10 @@ public:
 	void WriteLinkCSV(std::vector<Item*> src, std::vector<std::string> filter) { write_links(src, filter); }
 	bool write_links(std::vector<Item*> src, std::vector<std::string> subfilter);
 	void download_content(std::vector<Item*> i);
-	bool posts_only;
-	bool comments_only;
 
 private:
-
-	State get_saved_items(std::vector< Item* >& sitem, std::string after, bool get_comments);
+	State loadcheck(std::vector<Item*>& items);
+	State get_saved_items(std::vector< Item* >& sitem, std::string after);
 	State retrieve_comments(Item* i);
 
 

--- a/Saver.hpp
+++ b/Saver.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "curl/curl.h"
+
 #include <vector>
 #include <iosfwd>
 #include <sstream>
@@ -11,17 +11,26 @@
 #include <cctype>
 #include <algorithm>
 #include <iterator>
+#include <map>
+
+#include "curl/curl.h"
 #include "boost/algorithm/string.hpp"
 #include "base.hpp"
-#include <map>
-#ifdef _MSC_VER
-#include <filesystem>
-#elif defined(__GNUC__) && !(defined(__MINGW64__) || defined(__MINGW32__))
-#include <experimental/filesystem>
-#else
-#include <filesystem>
-#endif
 #include "Reddit.hpp"
+
+#if defined(__cpp_lib_filesystem)
+	#include <filesystem>
+	namespace fs = std::filesystem;
+#elif defined(__cpp_lib_experimental_filesystem)
+	#include <experimental/filesystem>
+	namespace fs = std::experimental::filesystem;
+#elif defined(USE_EXP_FS)
+	#include <experimental/filesystem>
+	namespace fs = std::experimental::filesystem;
+#else
+	#error "No filesystem support found :("
+#endif
+
 
 class Saver : public RedditAccess
 {
@@ -36,7 +45,7 @@ public:
 	void download_content(std::vector<Item*> i);
 
 private:
-	State loadcheck(std::vector<Item*>& items);
+	//State loadcheck(std::vector<Item*>& items);
 	State get_saved_items(std::vector< Item* >& sitem, std::string after);
 	State retrieve_comments(Item* i);
 

--- a/Source.cpp
+++ b/Source.cpp
@@ -46,8 +46,8 @@ int main(int argc, char* argv[])
 	s.init_logs();
 	std::cout << "Requesting access to Reddit..." << std::endl;
 	State w = s.AccessReddit();
-	if(s.imgur_enabled)
-		s.authorize_imgur();
+	//if(true)
+		//s.authorize_imgur();
 	if (w.http_state != 200)
 	{
 		std::cout << "Error, failed to get a Reddit access token, " << w.http_state << " : " << w.message << std::endl;

--- a/Source.cpp
+++ b/Source.cpp
@@ -46,6 +46,8 @@ int main(int argc, char* argv[])
 	s.init_logs();
 	std::cout << "Requesting access to Reddit..." << std::endl;
 	State w = s.AccessReddit();
+	if(s.imgur_enabled)
+		s.authorize_imgur();
 	if (w.http_state != 200)
 	{
 		std::cout << "Error, failed to get a Reddit access token, " << w.http_state << " : " << w.message << std::endl;

--- a/base.cpp
+++ b/base.cpp
@@ -49,4 +49,18 @@ bool _Item::IsPossibleImage()
 	return false;
 }
 
+// IsImgurLink only deals with single images whereas IsImgurAlbum deals with albums
+
+bool _Item::IsImgurAlbum()
+{
+	return (url.rfind("https://imgur.com/a/", 0) != std::string::npos);
+}
+
+bool _Item::IsImgurLink()
+{
+	return (url.rfind("https://imgur.com/", 0) != std::string::npos && url.rfind("https://imgur.com/a/",0) == std::string::npos);
+}
+
+State::State() : http_state(0), message("") {}
+
 CMDArgs::CMDArgs() : EnableImages(true), DisableComments(false), EnableText(true), RHA(false), limit(1000), username(""), sort(Subreddit), reverse(false){}

--- a/base.hpp
+++ b/base.hpp
@@ -80,13 +80,12 @@ public:
 	bool EnableImages, EnableText, DisableComments, RHA, reverse;
 	int limit;
 	std::string username;
-	std::vector<std::string> whitelist, blacklist, uwhitelist, ublacklist;
+	std::vector<std::string> whitelist, blacklist, uwhitelist, ublacklist, dblacklist, dwhitelist;
 	Sort sort;
 };
 
 struct creds {
 	std::string username, password, client_id, secret, user_agent;
-	std::string imgur_client_id, imgur_secret;
 };
 
 // Item holds items from user's saved

--- a/base.hpp
+++ b/base.hpp
@@ -86,6 +86,7 @@ public:
 
 struct creds {
 	std::string username, password, client_id, secret, user_agent;
+	std::string imgur_client_id, imgur_secret;
 };
 
 // Item holds items from user's saved

--- a/base.hpp
+++ b/base.hpp
@@ -46,11 +46,13 @@ size_t writedat(char* buffer, size_t size, size_t nmemb, std::string& src);
 // Convert unix epoch time to real date time
 std::string to_realtime(long timestamp);
 
-typedef struct _State
+class State
 {
-	int http_state;
-	std::string message;
-}State;
+public:
+		int http_state;
+		std::string message;
+		State();
+};
 
 typedef struct _com
 {
@@ -115,4 +117,6 @@ typedef struct _Item
 	bool IsVideo();
 	// This function quickly checks if a url is an imaged based off the domain name, and it is used for stats not to really determine if it seriously is an image
 	bool IsPossibleImage();
+	bool IsImgurLink();
+	bool IsImgurAlbum();
 }Item;


### PR DESCRIPTION
* RSA can now retrieve Imgur albums via Imgur api
* Single imgur images can be retrieved via Imgur api
* Added CMake flags USE_EXP_FS and USE_HOME_DIR
* Added options: bd and wd for blacklisting and whitelisting domains.
* Fixed a bug where the application would crash if a folder or file name was longer than 255 characters
* Fixed a bug where RSA would hang if 60 requests is hit.
* RSA now prints more information to the screen when running.
* Fixed a bug where -dc enabled comments and comments where disabled by default
* RSA no longer downloads Imgur albums as ZIPs 